### PR TITLE
Create mastodon embed shortcode

### DIFF
--- a/layouts/shortcodes/mastodon.html
+++ b/layouts/shortcodes/mastodon.html
@@ -1,0 +1,1 @@
+<iframe src="https://{{.Get "server" | default "mastodon.social"}}/@{{.Get "user"}}/{{.Get "id"}}/embed" class="mastodon-embed" style="max-width: 100%; border: 0" width="400" allowfullscreen="allowfullscreen"></iframe><script src="https://{{.Get "server" | default "mastodon.social"}}/embed.js" async="async"></script>


### PR DESCRIPTION
This shortcode can be used as follows:

```
{{<mastodon server="" user="" id="">}}
```

It defaults to mastodon.social server.


Closes #787

### Issue
<!--- Insert a link to the associated github issue here. -->

### Description

<!-- Insert details about what the changes being proposed are. -->

### Test Evidence

<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->